### PR TITLE
Fix Concurrent, Same-Server Connections with Same IP or Hardware

### DIFF
--- a/src/client/component/auth.cpp
+++ b/src/client/component/auth.cpp
@@ -175,7 +175,7 @@ namespace auth
 				return;
 			}
 
-			game::SV_DirectConnect(from);
+			game::SV_DirectConnectExternal(from);
 		}
 
 		void* get_direct_connect_stub()

--- a/src/client/component/auth.cpp
+++ b/src/client/component/auth.cpp
@@ -175,7 +175,7 @@ namespace auth
 				return;
 			}
 
-			game::SV_DirectConnectExternal(from);
+			game::SV_DirectConnect(from);
 		}
 
 		void* get_direct_connect_stub()

--- a/src/client/component/auth.cpp
+++ b/src/client/component/auth.cpp
@@ -63,6 +63,7 @@ namespace auth
 		std::string get_key_entropy()
 		{
 			std::string entropy{};
+			entropy.append(std::to_string(static_cast<int>(utils::cryptography::random::get_integer())));
 			entropy.append(utils::smbios::get_uuid());
 			entropy.append(get_hw_profile_guid());
 			entropy.append(get_protected_data());

--- a/src/client/component/network.cpp
+++ b/src/client/component/network.cpp
@@ -95,7 +95,7 @@ namespace network
 			return net_compare_base_address(a, b) && a->port == b->port;
 		}
 
-		void reconnect_migratated_client(void*, game::netadr_s* from, const int, const int, const char*,
+		void reconnect_migrated_client(void*, game::netadr_s* from, const int, const int, const char*,
 			const char*, bool)
 		{
 			// This happens when a client tries to rejoin after being recently disconnected, OR by a duplicated guid
@@ -242,7 +242,7 @@ namespace network
 				utils::hook::nop(0x554222_b, 6);
 
 				utils::hook::jump(0x4F1800_b, net_compare_address);
-				utils::hook::jump(0x4F1850_b, net_compare_base_address);
+				utils::hook::jump(0x4F1850_b, net_compare_address);
 
 				// don't establish secure conenction
 				utils::hook::set<uint8_t>(0x358C8D_b, 0xEB);
@@ -290,7 +290,7 @@ namespace network
 				utils::hook::set(0x59E8B0_b, 0xC301B0);
 
 				// don't try to reconnect client
-				utils::hook::jump(0x54D220_b, reconnect_migratated_client);
+				utils::hook::jump(0x54D220_b, reconnect_migrated_client);
 				utils::hook::nop(0x54E168_b, 4); // this crashes when reconnecting for some reason
 
 				// allow server owner to modify net_port before the socket bind

--- a/src/client/component/network.cpp
+++ b/src/client/component/network.cpp
@@ -104,15 +104,12 @@ namespace network
 			game::NET_OutOfBandPrint(game::NS_SERVER, from, "error\nYou are already connected to the server.");
 		}
 
+
+		//Sys_StringToSockAddr @ 0x59E810 has essentially the same functionality as this function, 
+		//but breaks with multiple clients from the same IP address. Thus, we use this instead.
 		SOCKET create_socket(const char* net_interface, int port, int protocol)
 		{
 			sockaddr_in address{};
-
-			if (net_interface && net_interface != "localhost"s)
-			{
-				// Sys_StringToSockaddr
-				utils::hook::invoke<void>(0x59E810_b, net_interface, &address);
-			}
 
 			address.sin_family = AF_INET;
 			address.sin_port = ntohs(static_cast<short>(port));

--- a/src/client/component/network.cpp
+++ b/src/client/component/network.cpp
@@ -104,12 +104,16 @@ namespace network
 			game::NET_OutOfBandPrint(game::NS_SERVER, from, "error\nYou are already connected to the server.");
 		}
 
-
-		//Sys_StringToSockAddr @ 0x59E810 has essentially the same functionality as this function, 
-		//but breaks with multiple clients from the same IP address. Thus, we use this instead.
 		SOCKET create_socket(const char* net_interface, int port, int protocol)
 		{
 			sockaddr_in address{};
+			
+			if (net_interface && net_interface != "localhost"s)
+			{
+				// Sys_StringToSockaddr
+				utils::hook::invoke<void>(0x59E810_b, net_interface, &address);
+			}
+
 
 			address.sin_family = AF_INET;
 			address.sin_port = ntohs(static_cast<short>(port));

--- a/src/client/game/symbols.hpp
+++ b/src/client/game/symbols.hpp
@@ -235,7 +235,7 @@ namespace game
 	WEAK symbol<const char*(scr_string_t stringValue)> SL_ConvertToString{0x3C0C50, 0x507CD0};
 	WEAK symbol<unsigned int(const char* str)> SL_GetCanonicalString{0x3BDA20, 0x504A00};
 
-	WEAK symbol<void(netadr_s* from)> SV_DirectConnect{0x0, 0x54DBF0};
+	WEAK symbol<void(netadr_s* from)> SV_DirectConnectExternal{0x0, 0x54DBF0};
 	WEAK symbol<void(int arg, char* buffer, int bufferLength)> SV_Cmd_ArgvBuffer{0x377D40, 0x1CAC60};
 	WEAK symbol<void(const char* text_in)> SV_Cmd_TokenizeString{0x377DC0, 0x1CACE0};
 	WEAK symbol<void()> SV_Cmd_EndTokenizedString{0x377D80, 0x1CACA0};

--- a/src/client/game/symbols.hpp
+++ b/src/client/game/symbols.hpp
@@ -235,7 +235,7 @@ namespace game
 	WEAK symbol<const char*(scr_string_t stringValue)> SL_ConvertToString{0x3C0C50, 0x507CD0};
 	WEAK symbol<unsigned int(const char* str)> SL_GetCanonicalString{0x3BDA20, 0x504A00};
 
-	WEAK symbol<void(netadr_s* from)> SV_DirectConnectExternal{0x0, 0x54DBF0};
+	WEAK symbol<void(netadr_s* from)> SV_DirectConnect{0x0, 0x54DBF0};
 	WEAK symbol<void(int arg, char* buffer, int bufferLength)> SV_Cmd_ArgvBuffer{0x377D40, 0x1CAC60};
 	WEAK symbol<void(const char* text_in)> SV_Cmd_TokenizeString{0x377DC0, 0x1CACE0};
 	WEAK symbol<void()> SV_Cmd_EndTokenizedString{0x377D80, 0x1CACA0};


### PR DESCRIPTION
# Issues Addressed

1. Attempting to connect multiple clients to the same server from the same computer fails, with various error messages. This disables functionality of H1-mod when attempting to use it with, for example, nucleus co-op. I have this identical issue on Linux when similarly attempting to splitscreen the application.

2. Attempting to connect multiple clients to the same server from the same IP fails, with any additional clients past the first hanging infinitely at "awaiting challenge..." Upon disconnection of the client with initially successful connection, the second client will immediately connect, and so forth. Essentially, only one client per IP is allowed to connect to a server at a time. This issue has been reported several times in the Discord server.

# Solutions
1. Currently, GUID key entropy is generated purely based on various hardware-specific parameters. As such, clients running on identical hardware will have identical GUIDs, and will fail to connect to a server concurrently. This was resolved by appending a random integer to GUID key entropy, de-duplicating client GUIDs with identical hardware

2. <s>This issue was resolved by a combination of the below two fixes.

    1. Half of this issue was caused by usage of the MWR-provided `Sys_StringToSockAddr`. `Sys_StringToSockAddr` fails when attempting to connect multiple clients with the same IP concurrently - it does not successfully differentiate by a combination of port *and* IP address. As it has nearly identical functionality as the existing function `create_socket`, and `create_socket` *does* successfully differentiate client sockets by a combination of client port and IP, this was resolved by *always* using `create_socket` in place of `Sys_StringToSockAddr`.

    2. </s>This issue was <s>simultaneously</s> caused by lack of differentiation of clients by both client port *and* client IP in `NET_CompareBaseAdr`. This was resolved by usage of h1-mod's `net_compare_address` in place of `NET_CompareBaseAdr`. 
    
        Despite the potentially wide impact of this change, in my testing and analysis, I have not noticed any unintended impact of this change. In `NET_CompareBaseAdr` provided by MWR, both `NA_BOT` and `NA_LOOPBACK` client address types are compared by port, so I believe it to be a simple oversight that either the `NA_IP` client address type would not be compared by port in `NET_CompareBaseAdr` as well, or more likely that `NET_CompareBaseAdr` was ever used in place of `NET_CompareAdr`, rather than just serving to abstract a portion of its original function. While this is a fairly sweeping change, it seems to only be a positive one.
    
        Specifically, I reviewed all eight places in the MWR binary where `NET_CompareBaseAdr` was called apart from in `NET_CompareAdr`; the substituted usage of h1-mod's `net_compare_address` seemed to only be a positive change in all eight locations. As mentioned previously, my testing also reflected this conclusion.

# Testing
I tested all solutions mentioned above in environments which replicate concurrent connections of both external and local clients, by usage of various combinations of VPNs. Clients connect as expected, even if both are from the same IP address or computer. I noticed no visible changes to functionality otherwise.

